### PR TITLE
Exit Button at the bottom of the application

### DIFF
--- a/rhinosystem/gtk/sysinfo.ui
+++ b/rhinosystem/gtk/sysinfo.ui
@@ -36,16 +36,30 @@
       </object>
     </child>
     <child>
-      <object class="GtkButton" id="upgrade_button">
+      <object class="GtkBox" id="buttons">
         <property name="margin-top">15px</property>
         <property name="margin-bottom">20px</property>
         <property name="valign">center</property>
         <property name="halign">center</property>
-        <property name="label">System Upgrade</property>
-        <style>
-          <class name="pill"/>
-          <class name="suggested-action"/>
-        </style>
+        <property name="orientation">horizontal</property>
+        <child>
+          <object class="GtkButton" id="upgrade_button">
+            <property name="label">System Upgrade</property>
+            <style>
+              <class name="pill"/>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="exit_button">
+            <property name="margin-start">15px</property>
+            <property name="label">Exit</property>
+            <style>
+              <class name="pill"/>
+            </style>
+          </object>
+        </child>
       </object>
     </child>
   </template>

--- a/rhinosystem/gtk/upgrade.ui
+++ b/rhinosystem/gtk/upgrade.ui
@@ -31,12 +31,12 @@
         <property name="valign">fill</property>
         <property name="halign">center</property>
         <property name="hexpand">true</property>
-	<property name="vexpand">true</property>
-	<property name="margin-bottom">20</property>
-	<child>
+	      <property name="vexpand">true</property>
+	      <property name="margin-bottom">20</property>
+	      <child>
           <object class="GtkButton" id="quitButton">
             <property name="label">Exit Application</property>
-	    <style>
+	          <style>
               <class name="suggested-action"/>
               <class name="pill"/>
             </style>

--- a/rhinosystem/views/sysinfo.py
+++ b/rhinosystem/views/sysinfo.py
@@ -37,6 +37,7 @@ class SysinfoView(Gtk.Box):
     os: Inforow = Gtk.Template.Child()
 
     upgrade_button: Gtk.Button = Gtk.Template.Child()
+    exit_button: Gtk.Button = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/rhinosystem/window.py
+++ b/rhinosystem/window.py
@@ -39,6 +39,7 @@ class RhinosystemWindow(Adw.ApplicationWindow):
         self.os_info = SysinfoView()
         self.upgrade_progress = UpgradeView()
         self.os_info.upgrade_button.connect("clicked", self.upgrade_os)
+        self.os_info.exit_button.connect("clicked", quit)
         self.stack_view.add_child(self.os_info)
         self.stack_view.add_child(self.upgrade_progress)
         self.version.set_label(DeviceInfo().get_os_version())

--- a/rhinosystem/window.ui
+++ b/rhinosystem/window.ui
@@ -38,6 +38,15 @@
           </object>
         </child>
         <child>
+          <object class="GtkLabel" id="subtitle">
+            <property name="margin-top">2px</property>
+            <property name="label">Let's get Ubuntu rolling</property>
+            <style>
+              <class name="dim-label"/>
+            </style>
+          </object>
+        </child>
+        <child>
           <object class="GtkLabel" id="version">
             <property name="margin-top">5px</property>
             <property name="label">Failed to fetch version</property>

--- a/rhinosystem/window.ui
+++ b/rhinosystem/window.ui
@@ -38,15 +38,6 @@
           </object>
         </child>
         <child>
-          <object class="GtkLabel" id="subtitle">
-            <property name="margin-top">2px</property>
-            <property name="label">Let's get Ubuntu rolling</property>
-            <style>
-              <class name="dim-label"/>
-            </style>
-          </object>
-        </child>
-        <child>
           <object class="GtkLabel" id="version">
             <property name="margin-top">5px</property>
             <property name="label">Failed to fetch version</property>


### PR DESCRIPTION
It lives with the Upgrade Button.
![grafik](https://github.com/rhino-linux/rhino-system/assets/95766563/2dce1c1d-58ce-473e-bfa2-557c688ab2aa)

Note: The "Let's get Ubuntu rolling" text was removed in commit `Exit Button` after ajstrong informed me that this has not been the tagline for a long time.