### PR TITLE
You can now copy the version by clicking on it

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Following dependencies are required
 - gettext
 - desktop-file-utils
 - meson
+- xclip
 
 To build and install rhino-system simply run
 ```

--- a/rhinosystem/gtk/sysinfo.ui
+++ b/rhinosystem/gtk/sysinfo.ui
@@ -36,30 +36,16 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox" id="buttons">
+      <object class="GtkButton" id="upgrade_button">
         <property name="margin-top">15px</property>
         <property name="margin-bottom">20px</property>
         <property name="valign">center</property>
         <property name="halign">center</property>
-        <property name="orientation">horizontal</property>
-        <child>
-          <object class="GtkButton" id="upgrade_button">
-            <property name="label">System Upgrade</property>
-            <style>
-              <class name="pill"/>
-              <class name="suggested-action"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="exit_button">
-            <property name="margin-start">15px</property>
-            <property name="label">Exit</property>
-            <style>
-              <class name="pill"/>
-            </style>
-          </object>
-        </child>
+        <property name="label">System Upgrade</property>
+        <style>
+          <class name="pill"/>
+          <class name="suggested-action"/>
+        </style>
       </object>
     </child>
   </template>

--- a/rhinosystem/views/sysinfo.py
+++ b/rhinosystem/views/sysinfo.py
@@ -37,7 +37,6 @@ class SysinfoView(Gtk.Box):
     os: Inforow = Gtk.Template.Child()
 
     upgrade_button: Gtk.Button = Gtk.Template.Child()
-    exit_button: Gtk.Button = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/rhinosystem/views/sysinfo.py
+++ b/rhinosystem/views/sysinfo.py
@@ -47,7 +47,7 @@ class SysinfoView(Gtk.Box):
         self.gpu.set_title("GPU")
         self.kernel.set_title("Kernel")
         self.desktop.set_title("Desktop")
-        self.os.set_title("OS")
+        self.os.set_title("Operating System")
 
         # Run these functions asynchronously since they can take a while to run (mainly cpu)
         RunAsync(self.set_system_info, None, self.board)

--- a/rhinosystem/window.py
+++ b/rhinosystem/window.py
@@ -40,7 +40,6 @@ class RhinosystemWindow(Adw.ApplicationWindow):
         self.upgrade_progress = UpgradeView()
         self.version.connect("clicked", self.copy_version)
         self.os_info.upgrade_button.connect("clicked", self.upgrade_os)
-        self.os_info.exit_button.connect("clicked", quit)
         self.stack_view.add_child(self.os_info)
         self.stack_view.add_child(self.upgrade_progress)
         if DeviceInfo().get_os_version() != "Unknown":

--- a/rhinosystem/window.py
+++ b/rhinosystem/window.py
@@ -16,9 +16,8 @@
 #
 # SPDX-License-Identifier: GPL-3.0-only
 
-from gi.repository import Adw
-from gi.repository import Gtk
-from gi.repository import GLib
+from gi.repository import Adw, Gtk, Gdk, GLib
+from os import system
 import time
 from rhinosystem.views.sysinfo import SysinfoView
 from rhinosystem.views.upgrade import UpgradeView
@@ -31,20 +30,29 @@ class RhinosystemWindow(Adw.ApplicationWindow):
     __gtype_name__ = 'RhinosystemWindow'
 
     stack_view: Gtk.Stack = Gtk.Template.Child()
-    version: Gtk.Label = Gtk.Template.Child()
+    version: Gtk.Button = Gtk.Template.Child()
+    version_invalid: Gtk.Button = Gtk.Template.Child()
     title: Gtk.Label = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.os_info = SysinfoView()
         self.upgrade_progress = UpgradeView()
+        self.version.connect("clicked", self.copy_version)
         self.os_info.upgrade_button.connect("clicked", self.upgrade_os)
         self.stack_view.add_child(self.os_info)
         self.stack_view.add_child(self.upgrade_progress)
-        self.version.set_label(DeviceInfo().get_os_version())
+        if DeviceInfo().get_os_version() != "Unknown":
+            validation: float = float(DeviceInfo().get_os_version())
+            self.version_invalid.set_visible(False)
+            self.version.set_label(DeviceInfo().get_os_version())
+        else: self.version.set_visible(False)
 
     def upgrade_os(self, widget):
         self.os_info.set_visible(False)
         self.upgrade_progress.set_visible(True)
         self.upgrade_progress.on_show(self)
         self.title.set_label("Updating Rhino Linux")
+
+    def copy_version(self, widget):
+        system(f"echo -n \"{DeviceInfo().get_os_version()}\" | xclip -selection c")

--- a/rhinosystem/window.ui
+++ b/rhinosystem/window.ui
@@ -38,11 +38,26 @@
           </object>
         </child>
         <child>
-          <object class="GtkLabel" id="version">
+          <object class="GtkButton" id="version_invalid">
             <property name="margin-top">5px</property>
+            <property name="halign">center</property>
             <property name="label">Failed to fetch version</property>
             <style>
-              <class name="dim-label"/>
+              <class name="error"/>
+              <class name="pill"/>
+              <class name="flat"/>
+            </style>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="version">
+            <property name="margin-top">5px</property>
+            <property name="halign">center</property>
+            <property name="label">no_version_set</property>
+            <style>
+              <class name="accent"/>
+              <class name="pill"/>
+              <class name="flat"/>
             </style>
           </object>
         </child>


### PR DESCRIPTION
Quick Summary of the main changes
- The object with id "variable" has been swapped out for a `GtkButton` with the styles `accent` `flat` `pill`
- When clicked on, this new button will copy the version number of the current Rhino Linux install to the users clipboard using xclip
- If no version could be found, the element with the id "version_invalid" will be unhidden, and "version" will be hidden
- "version_invalid" is a `GtkButton` with style classes `error` `flat` `pill`, displaying the previous error message.