### PR TITLE
ui: allow window resizing.

### DIFF
--- a/rhinosystem/gtk/sysinfo.ui
+++ b/rhinosystem/gtk/sysinfo.ui
@@ -5,34 +5,40 @@
   <template class="SysinfoView" parent="GtkBox">
     <property name="orientation">vertical</property>
     <child>
-      <object class="GtkListBox">
-        <child>
-          <object class="Inforow" id="board"/>
-        </child>
-        <child>
-          <object class="Inforow" id="chip"/>
-        </child>
-        <child>
-          <object class="Inforow" id="memory"/>
-        </child>
-        <child>
-          <object class="Inforow" id="disk"/>
-        </child>
-        <child>
-          <object class="Inforow" id="gpu"/>
-        </child>
-        <child>
-          <object class="Inforow" id="kernel"/>
-        </child>
-        <child>
-          <object class="Inforow" id="desktop"/>
-        </child>
-        <child>
-          <object class="Inforow" id="os"/>
-        </child>
-        <style>
-          <class name="boxed-list"/>
-        </style>
+      <object class="GtkScrolledWindow">
+        <property name="hscrollbar-policy">never</property>
+        <property name="vscrollbar-policy">automatic</property>
+        <property name="child">
+          <object class="GtkListBox">
+            <child>
+              <object class="Inforow" id="board"/>
+            </child>
+            <child>
+              <object class="Inforow" id="chip"/>
+            </child>
+            <child>
+              <object class="Inforow" id="memory"/>
+            </child>
+            <child>
+              <object class="Inforow" id="disk"/>
+            </child>
+            <child>
+              <object class="Inforow" id="gpu"/>
+            </child>
+            <child>
+              <object class="Inforow" id="kernel"/>
+            </child>
+            <child>
+              <object class="Inforow" id="desktop"/>
+            </child>
+            <child>
+              <object class="Inforow" id="os"/>
+            </child>
+            <style>
+              <class name="boxed-list"/>
+            </style>
+          </object>
+        </property>
       </object>
     </child>
     <child>

--- a/rhinosystem/gtk/sysinfo.ui
+++ b/rhinosystem/gtk/sysinfo.ui
@@ -9,6 +9,7 @@
         <property name="hscrollbar-policy">never</property>
         <property name="vscrollbar-policy">automatic</property>
         <property name="vexpand">true</property>
+        <property name="propagate-natural-height">true</property>
         <property name="child">
           <object class="GtkListBox">
             <child>

--- a/rhinosystem/gtk/sysinfo.ui
+++ b/rhinosystem/gtk/sysinfo.ui
@@ -8,6 +8,7 @@
       <object class="GtkScrolledWindow">
         <property name="hscrollbar-policy">never</property>
         <property name="vscrollbar-policy">automatic</property>
+        <property name="vexpand">true</property>
         <property name="child">
           <object class="GtkListBox">
             <child>

--- a/rhinosystem/window.ui
+++ b/rhinosystem/window.ui
@@ -8,8 +8,6 @@
     <property name="resizable">true</property>
     <child>
       <object class="GtkBox" id="welcome">
-        <property name="valign">fill</property>
-        <property name="halign">fill</property>
         <property name="orientation">vertical</property>
         <child>
           <object class="AdwHeaderBar" id="header_bar">
@@ -22,51 +20,58 @@
           </object>
         </child>
         <child>
-          <object class="GtkImage">
-            <property name="icon-name">org.rhinolinux</property>
-            <property name="pixel-size">100</property>
+          <object class="GtkBox">
+            <property name="orientation">vertical</property>
+            <property name="vexpand">true</property>
             <property name="valign">center</property>
-            <property name="halign">center</property>
-          </object>
-        </child>
-        <child>
-          <object class="GtkLabel" id="title">
-            <property name="label">Rhino Linux</property>
-            <style>
-              <class name="bold"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="version_invalid">
-            <property name="margin-top">5px</property>
-            <property name="halign">center</property>
-            <property name="label">Failed to fetch version</property>
-            <style>
-              <class name="error"/>
-              <class name="pill"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkButton" id="version">
-            <property name="margin-top">5px</property>
-            <property name="halign">center</property>
-            <property name="label">no_version_set</property>
-            <style>
-              <class name="accent"/>
-              <class name="pill"/>
-            </style>
-          </object>
-        </child>
-        <child>
-          <object class="GtkStack" id="stack_view">
-            <property name="margin-top">20</property>
-            <property name="margin-start">40</property>
-            <property name="margin-end">40</property>
-            <property name="valign">center</property>
-            <property name="halign">fill</property>
-            <property name="transition-type">crossfade</property>
+            <child>
+              <object class="GtkImage">
+                <property name="icon-name">org.rhinolinux</property>
+                <property name="pixel-size">100</property>
+                <property name="valign">center</property>
+                <property name="halign">center</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="title">
+                <property name="label">Rhino Linux</property>
+                <style>
+                  <class name="bold"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="version_invalid">
+                <property name="margin-top">5px</property>
+                <property name="halign">center</property>
+                <property name="label">Failed to fetch version</property>
+                <style>
+                  <class name="error"/>
+                  <class name="pill"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkButton" id="version">
+                <property name="margin-top">5px</property>
+                <property name="halign">center</property>
+                <property name="label">no_version_set</property>
+                <style>
+                  <class name="accent"/>
+                  <class name="pill"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkStack" id="stack_view">
+                <property name="margin-top">20</property>
+                <property name="margin-start">40</property>
+                <property name="margin-end">40</property>
+                <property name="valign">start</property>
+                <property name="halign">fill</property>
+                <property name="transition-type">crossfade</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/rhinosystem/window.ui
+++ b/rhinosystem/window.ui
@@ -4,7 +4,7 @@
   <requires lib="Adw" version="1.0"/>
   <template class="RhinosystemWindow" parent="AdwApplicationWindow">
     <property name="default-width">600</property>
-    <property name="default-height">625</property>
+    <property name="default-height">800</property>
     <property name="resizable">true</property>
     <child>
       <object class="GtkBox" id="welcome">

--- a/rhinosystem/window.ui
+++ b/rhinosystem/window.ui
@@ -5,7 +5,7 @@
   <template class="RhinosystemWindow" parent="AdwApplicationWindow">
     <property name="default-width">600</property>
     <property name="default-height">625</property>
-    <property name="resizable">false</property>
+    <property name="resizable">true</property>
     <child>
       <object class="GtkBox" id="welcome">
         <property name="valign">fill</property>


### PR DESCRIPTION
This new PR addresses an issue the [old one](https://github.com/rhino-linux/rhino-system/pull/30) had, which was that the GtkScrolledWindow not taking up all available vertical space to it and only one row showed up at a time.

Before:
<img width="511" height="201" alt="image" src="https://github.com/user-attachments/assets/ba370ee3-9d64-4f3a-8e6d-3a4787b2b742" />
After:
<img width="576" height="437" alt="image" src="https://github.com/user-attachments/assets/8f474653-e656-45e0-9985-f98b2ab4717b" />

